### PR TITLE
use changelog to publish, code refactoring

### DIFF
--- a/packages/fynpo/src/fynpo-cli.ts
+++ b/packages/fynpo/src/fynpo-cli.ts
@@ -10,6 +10,7 @@ import Run from "./run";
 import Init from "./init";
 import Updated from "./updated";
 import Commitlint from "./commitlint";
+import Version from "./version";
 import makePkgDeps from "./make-pkg-deps";
 import readPackages from "./read-packages";
 import logger from "./logger";
@@ -78,6 +79,12 @@ const execPublish = (parsed) => {
   return new Publish(opts, readPackages(opts.cwd)).exec();
 };
 
+const execVersion = (parsed) => {
+  const opts = Object.assign({ cwd: process.cwd() }, parsed.opts);
+
+  return new Version(opts, makePkgDeps(readPackages(opts.cwd), parsed.opts)).exec();
+};
+
 const execRunScript = (parsed) => {
   const opts = Object.assign({ cwd: process.cwd() }, parsed.opts);
 
@@ -140,17 +147,23 @@ const nixClap = new NixClap({
       desc: "level of deps to include even if they were ignored",
       allowCmd: ["bootstrap", "local", "run"],
     },
+    commit: {
+      type: "boolean",
+      default: true,
+      desc: "no-commit to disable committing the changes to changelog and package.json",
+      allowCmd: ["changelog", "version", "prepare"],
+    },
     "force-publish": {
       alias: "fp",
       type: "string array",
       desc: "force publish packages",
-      allowCmd: ["updated", "changelog"],
+      allowCmd: ["updated", "changelog", "version"],
     },
     "ignore-changes": {
       alias: "ic",
       type: "string array",
       desc: "ignore patterns",
-      allowCmd: ["updated", "changelog"],
+      allowCmd: ["updated", "changelog", "version"],
     },
     "save-log": {
       alias: "sl",
@@ -209,6 +222,13 @@ const nixClap = new NixClap({
       alias: "c",
       desc: "Update changelog",
       exec: execChangelog,
+      options: {
+        publish: {
+          type: "boolean",
+          default: false,
+          desc: "enable to trigger publish with changelog commit",
+        }
+      }
     },
     run: {
       alias: "r",
@@ -248,6 +268,18 @@ const nixClap = new NixClap({
           type: "boolean",
           default: true,
           desc: "no-sort to disable topological sorting",
+        },
+      },
+    },
+    version: {
+      alias: "v",
+      desc: "Update changelog and bump version",
+      exec: execVersion,
+      options: {
+        tag: {
+          type: "boolean",
+          default: false,
+          desc: "create tags for individual packages",
         },
       },
     },

--- a/packages/fynpo/src/prepare.ts
+++ b/packages/fynpo/src/prepare.ts
@@ -1,4 +1,4 @@
-/* eslint-disable max-statements, no-magic-numbers */
+/* eslint-disable max-statements, no-magic-numbers, consistent-return */
 
 import Fs from "fs";
 import Path from "path";
@@ -14,55 +14,69 @@ import * as utils from "./utils";
 // prepare packages for publish
 
 class Prepare {
+  name;
   _cwd;
-  _tag;
   _fynpoRc;
   _markers;
   _data;
   _versions;
   _tags;
+  _options;
+  _gitClean;
 
-  constructor({ cwd, tag }, data) {
-    this._cwd = cwd;
-    this._tag = tag;
+  constructor(opts, data) {
+    this.name = "prepare";
+    this._cwd = opts.cwd;
 
     const { fynpoRc, dir } = utils.loadConfig(this._cwd);
 
-    this._cwd = dir || cwd;
+    this._cwd = dir || opts.cwd;
     this._fynpoRc = fynpoRc || {};
 
     this._markers = this._fynpoRc.changeLogMarkers || ["## Packages", "## Commits"];
     this._data = data;
     this._versions = {};
     this._tags = [];
+
+    const commandConfig = (this._fynpoRc as any).command || {};
+    const overrides = commandConfig[this.name];
+    this._options = _.defaults(opts, overrides, this._fynpoRc);
   }
 
   updateDep(pkg, name, ver) {
-    ["dependencies", "optionalDependencies", "peerDependencies", "devDependencies"].forEach(sec => {
-      const deps = pkg[sec];
-      if (_.isEmpty(deps) || !deps.hasOwnProperty(name)) {
-        return;
+    ["dependencies", "optionalDependencies", "peerDependencies", "devDependencies"].forEach(
+      (sec) => {
+        const deps = pkg[sec];
+        if (_.isEmpty(deps) || !deps.hasOwnProperty(name)) {
+          return;
+        }
+
+        let semType = "";
+        const sem = deps[name][0];
+
+        if (sem.match(/[\^~]/)) {
+          semType = sem;
+        } else if (!sem.match(/[0-9]/)) {
+          return;
+        }
+
+        deps[name] = `${semType}${ver}`;
       }
-
-      let semType = "";
-      const sem = deps[name][0];
-
-      if (sem.match(/[\^~]/)) {
-        semType = sem;
-      } else if (!sem.match(/[0-9]/)) {
-        return;
-      }
-
-      deps[name] = `${semType}${ver}`;
-    });
+    );
   }
+
+  checkGitClean = () => {
+    return this._sh(`git diff --quiet`)
+      .then(() => (this._gitClean = true))
+      .catch(() => (this._gitClean = false));
+  };
 
   _sh(command) {
     return xsh.exec(
       {
         silent: true,
         cwd: this._cwd,
-        env: Object.assign({}, process.env, { PWD: this._cwd })
+        env: Object.assign({}, process.env, { PWD: this._cwd }),
       },
       command
     );
@@ -77,7 +91,7 @@ class Prepare {
     let updated;
 
     if (fynpoTags) {
-      Object.keys(fynpoTags).find(tag => {
+      Object.keys(fynpoTags).find((tag) => {
         const tagInfo = fynpoTags[tag];
         if (tagInfo.enabled === false) {
           return undefined;
@@ -86,7 +100,7 @@ class Prepare {
         let enabled = _.get(tagInfo, ["packages", pkgJson.name]);
 
         if (enabled === undefined && tagInfo.regex) {
-          enabled = Boolean(tagInfo.regex.find(r => new RegExp(r).exec(pkgJson.name)));
+          enabled = Boolean(tagInfo.regex.find((r) => new RegExp(r).exec(pkgJson.name)));
         }
 
         const tagPkgs = _.get(tagInfo, "packages");
@@ -123,7 +137,7 @@ class Prepare {
       logger.warn(
         Chalk.red(
           `Pkg ${pkgJson.name} has exist publishConfig.tag ${existPubConfig.tag} \
-that's not latest but none set in lerna.json`
+that's not latest but none set in fynpo config`
         )
       );
       // existPubConfig.tag = "latest";
@@ -132,7 +146,39 @@ that's not latest but none set in lerna.json`
     pkgJson.version = newV;
   }
 
-  exec() {
+  commitAndTagUpdates = (packages) => {
+    if (!this._options.commit) {
+      logger.warn("commit option disabled, skip committing updates.");
+      return;
+    }
+
+    if (!this._gitClean) {
+      logger.warn("Your git branch is not clean, skip committing updates.");
+      return;
+    }
+
+    return this._sh(`git add ${packages.map((x) => `"${x}"`).join(" ")}`)
+      .then((output) => {
+        logger.info("git add", output);
+        return this._sh(`git commit -m [Publish] -m " - ${this._tags.join("\n - ")}"`);
+      })
+      .then((output) => {
+        logger.info("git commit", output);
+
+        if (this._options.tag === false) {
+          return false;
+        }
+
+        return Promise.each(this._tags, (tag) => {
+          logger.info("tagging", tag);
+          return this._sh(`git tag ${tag}`).then((tagOut) => {
+            logger.info("tag", tag, "output", tagOut);
+          });
+        });
+      });
+  };
+
+  async exec() {
     this.readChangelog();
     if (_.isEmpty(this._versions)) {
       logger.error("No versions found in CHANGELOG.md");
@@ -161,30 +207,14 @@ that's not latest but none set in lerna.json`
       packages.push(Path.join("packages", pkg.pkgDir, "package.json"));
     });
 
+    await this.checkGitClean();
+
     // all updated, write to disk
-    _.each(this._data.packages, pkg => {
+    _.each(this._data.packages, (pkg) => {
       Fs.writeFileSync(pkg.pkgFile, `${JSON.stringify(pkg.pkgJson, null, 2)}\n`);
     });
 
-    return this._sh(`git add ${packages.map(x => `"${x}"`).join(" ")}`)
-      .then(output => {
-        logger.info("git add", output);
-        return this._sh(`git commit -m [Publish] -m " - ${this._tags.join("\n - ")}"`);
-      })
-      .then(output => {
-        logger.info("git commit", output);
-
-        if (this._tag === false) {
-          return false;
-        }
-
-        return Promise.each(this._tags, tag => {
-          logger.info("tagging", tag);
-          return this._sh(`git tag ${tag}`).then(tagOut => {
-            logger.info("tag", tag, "output", tagOut);
-          });
-        });
-      });
+    return this.commitAndTagUpdates(packages);
   }
 
   readChangelog() {

--- a/packages/fynpo/src/updated.ts
+++ b/packages/fynpo/src/updated.ts
@@ -2,6 +2,7 @@
 import * as utils from "./utils";
 import logger from "./logger";
 import { execSync } from "./child-process";
+import getUpdatedPackages from "./utils/get-updated-packages";
 import _ from "lodash";
 import path from "path";
 import slash from "slash";
@@ -12,6 +13,8 @@ export default class Updated {
   _options;
   name;
   _packages;
+  _versionLockMap;
+  _lockAll;
 
   constructor(opts, data) {
     this.name = "updated";
@@ -19,129 +22,30 @@ export default class Updated {
     this._cwd = dir || opts.cwd;
     this._packages = data.packages;
 
-    const commandConfig = (fynpoRc as any).command || {};
-    const overrides = [this.name, ...this.relatedCommands].map((key) => commandConfig[key]);
-    this._options = _.defaults(opts, ...overrides, fynpoRc);
-  }
-
-  get relatedCommands() {
-    return ["changelog"];
-  }
-
-  ifTagExists(execOptions) {
-    let result = false;
-
-    try {
-      result = !!execSync("git", ["tag", "--list", "fynpo-rel-*"], execOptions);
-    } catch (err) {
-      logger.warn("Can't find latest release tag from this branch!");
-    }
-
-    return result;
-  }
-
-  getLatestTag(execOptions) {
-    const args = ["describe", "--long", "--first-parent", "--match", "fynpo-rel-*"];
-    const stdout = execSync("git", args, execOptions);
-    const [, tagName, commitCount, sha] = /^(.*)-(\d+)-g([0-9a-f]+)$/.exec(stdout) || [];
-    return { tagName, commitCount, sha };
-  }
-
-  addDependents(name, updates) {
-    const dependents = _.get(this._packages, [name, "dependents"], {});
-    dependents.forEach((dep) => {
-      if (!updates.includes(dep)) {
-        updates.push(dep);
-      }
-    });
-  }
-
-  getUpdatedPackages(execOptions) {
-    let latestTag;
-    const updates = [];
-    const forced = this._options.forcePublish || [];
-
-    if (this.ifTagExists(execOptions)) {
-      const { tagName, commitCount } = this.getLatestTag(execOptions);
-
-      if (commitCount === "0" && forced.length === 0) {
-        logger.info("No commits since previous release. Skipping change detection");
-        return [];
-      }
-
-      latestTag = tagName;
-    }
-
-    if (!latestTag || forced.includes("*")) {
-      logger.info("Assuming all packages changed.");
-      Object.keys(this._packages).forEach((name) => {
-        updates.push(name);
-      });
+    this._versionLockMap = {};
+    const versionLocks = _.get(fynpoRc, "versionLocks", []);
+    if (versionLocks[0] && versionLocks[0] === "*") {
+      this._lockAll = true;
     } else {
-      logger.info(`Detecting changed packages since the release tag: ${latestTag}`);
-
-      const ignoreChanges = this._options.ignoreChanges || [];
-      if (ignoreChanges.length) {
-        logger.info("Ignoring changes in files matching patterns:", ignoreChanges);
-      }
-      const filterFunctions = ignoreChanges.map((p) =>
-        minimatch.filter(`!${p}`, {
-          matchBase: true,
-          dot: true,
-        })
-      );
-
-      const isForced = (name) => {
-        if (forced.includes("*") || forced.includes(name)) {
-          logger.info(`force updating package: ${name}`);
-          return true;
-        }
-        return false;
-      };
-
-      const isChanged = (name) => {
-        const pkg = this._packages[name];
-
-        const args = ["diff", "--name-only", latestTag];
-        const pathArg = slash(path.relative(this._cwd, pkg.path));
-        if (pathArg) {
-          args.push("--", pathArg);
-        }
-
-        const diff = execSync("git", args, execOptions);
-        if (diff === "") {
-          return false;
-        }
-
-        let changedFiles = diff.split("\n");
-        if (filterFunctions.length) {
-          for (const filerFn of filterFunctions) {
-            changedFiles = changedFiles.filter(filerFn);
-          }
-        }
-
-        return changedFiles.length > 0;
-      };
-
-      Object.keys(this._packages).forEach((name) => {
-        if (isForced(name) || isChanged(name)) {
-          updates.push(name);
-        }
-      });
-
-      updates.forEach((name) => {
-        this.addDependents(name, updates);
-      });
+      versionLocks.reduce((mapping, locks) => {
+        locks.forEach((name) => (mapping[name] = locks));
+        return mapping;
+      }, this._versionLockMap);
     }
 
-    return updates;
+    const commandConfig = (fynpoRc as any).command || {};
+    const overrides = commandConfig[this.name];
+    this._options = _.defaults(opts, overrides, fynpoRc);
   }
 
   exec() {
-    const execOptions = {
+    const opts = Object.assign({}, this._options, {
       cwd: this._cwd,
-    };
-    const updates = this.getUpdatedPackages(execOptions);
+      lockAll: this._lockAll,
+      versionLockMap: this._versionLockMap,
+    });
+
+    const { pkgs: updates } = getUpdatedPackages({ packages: this._packages }, opts);
 
     if (!updates.length) {
       logger.info(`No changed packages!`);

--- a/packages/fynpo/src/utils/get-current-branch.ts
+++ b/packages/fynpo/src/utils/get-current-branch.ts
@@ -1,0 +1,9 @@
+import logger from "../logger";
+import { execSync } from "../child-process";
+
+export const getCurrentBranch = (opts) => {
+  const branch = execSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], opts);
+  logger.info("currentBranch", branch);
+
+  return branch;
+};

--- a/packages/fynpo/src/utils/get-package-version.ts
+++ b/packages/fynpo/src/utils/get-package-version.ts
@@ -1,0 +1,169 @@
+/* eslint-disable complexity, consistent-return, max-depth */
+
+import _ from "lodash";
+import * as utils from "../utils";
+import semver from "semver";
+import logger from "../logger";
+
+const findVersion = (name, updateType, collated) => {
+  const packages = _.get(collated, "opts.data.packages", {});
+  const types = ["patch", "minor", "major"];
+  const Pkg = _.get(packages, [name, "pkgJson"], {});
+  collated.packages[name] = collated.packages[name] || {};
+
+  collated.packages[name].version = Pkg.version;
+  const x = semver.parse(Pkg.version);
+  collated.packages[name].versionOnly = `${x.major}.${x.minor}.${x.patch}`;
+  collated.packages[name].semver = x;
+  collated.packages[name].newVersion = semver.inc(
+    collated.packages[name].versionOnly,
+    types[updateType]
+  );
+  collated.packages[name].updateType = updateType;
+  collated.packages[name].originalPkg = Pkg;
+};
+
+const findUpdateType = (name, collated, minBumpType = 0) => {
+  const opts = collated.opts || {};
+  const lintConfig = opts.fynpoRc.commitlint;
+  const parserOpts = _.get(lintConfig, "parserPreset.parserOpts", {});
+
+  collated.packages[name] = collated.packages[name] || {};
+  const msgs = collated.packages[name].msgs || [];
+
+  const updateType = msgs.reduce((a, x) => {
+    const parsed: any = utils.lintParser(x.m, parserOpts);
+    if ((parsed.type && parsed.type === "major") || x.m.indexOf("[maj") >= 0) {
+      if (a < 2) {
+        a = 2;
+      }
+    } else if ((parsed.type && parsed.type === "minor") || x.m.indexOf("[min") >= 0) {
+      if (a < 1) {
+        a = 1;
+      }
+    }
+    return a;
+  }, minBumpType);
+
+  collated.packages[name].updateType = updateType;
+};
+
+export const determinePackageVersions = (collated) => {
+  const opts = collated.opts || {};
+  const changed = collated.changed || {};
+  const packages = _.get(collated, "opts.data.packages", {});
+
+  // find bump type for packages that have direct changes
+  collated.realPackages.forEach((name) => findUpdateType(name, collated));
+
+  // If all packages are version locked, bump all the packages to the highest type
+  if (opts.lockAll) {
+    const updateTypes = collated.realPackages
+      .map((name) => collated.packages[name])
+      .map((x) => x.updateType);
+    const minBumpType = _.max(updateTypes);
+
+    for (const name of Object.keys(packages)) {
+      if (!collated.realPackages.includes(name)) {
+        collated.realPackages.push(name);
+      }
+      findVersion(name, minBumpType, collated);
+    }
+
+    const directBumps = collated.realPackages.filter(
+      (name) => collated.packages[name] && collated.packages[name].newVersion
+    );
+    collated.directBumps = directBumps;
+    collated.indirectBumps = [];
+    return Promise.resolve(collated);
+  }
+
+  // check for forceUpdated packages
+
+  changed.forceUpdated.forEach((name) => {
+    if (!collated.realPackages.includes(name)) {
+      collated.realPackages.push(name);
+      findUpdateType(name, collated);
+    } else {
+      const pkgType = _.get(collated.packages, [name, "updateType"], 0);
+      const updateType = _.max([collated.packages[name].updateType, pkgType]);
+      collated.packages[name].updateType = updateType;
+    }
+  });
+
+  // check for version locking of direct bump packages
+  collated.realPackages.forEach((name) => {
+    const verLocks = changed.verLocks[name];
+    if (verLocks) {
+      for (const lockPkgName of verLocks) {
+        if (!collated.realPackages.includes(lockPkgName)) {
+          collated.realPackages.push(lockPkgName);
+          findUpdateType(lockPkgName, collated, collated.packages[name].updateType);
+        } else {
+          const pkgType = _.get(collated.packages, [lockPkgName, "updateType"], 0);
+          const updateType = _.max([collated.packages[name].updateType, pkgType]);
+          collated.packages[lockPkgName].updateType = updateType;
+        }
+      }
+    }
+  });
+
+  const indirectBumps = [];
+
+  // update any package that depend on a directly bumped packages or its version locks
+  let count = 0;
+  do {
+    count = 0;
+    const dependents = Object.keys(changed.depMap);
+    for (const name of dependents) {
+      const pkgType = _.get(collated.packages, [name, "updateType"], 0);
+      const deps = changed.depMap[name];
+
+      const updateTypes = deps
+        .map((depName) => collated.packages[depName])
+        .map((x) => x.updateType);
+      if (updateTypes.length > 0) {
+        const minBumpType = _.max([pkgType, ...updateTypes]);
+        if (collated.realPackages.includes(name)) {
+          if (minBumpType !== pkgType) {
+            collated.packages[name].updateType = minBumpType;
+            count++;
+          }
+        } else {
+          findUpdateType(name, collated, minBumpType);
+          indirectBumps.push(name);
+        }
+      }
+    }
+  } while (count > 0);
+
+  // check for version locking of indirect bump packages
+  const indirectLockBumps = indirectBumps.filter((pkgName) => {
+    const verLocks = opts.versionLockMap[pkgName];
+    if (verLocks) {
+      logger.info("version locks:", pkgName, verLocks);
+      for (const lockPkgName of _.without(verLocks, pkgName)) {
+        if (!indirectBumps.includes(lockPkgName)) {
+          findUpdateType(lockPkgName, collated, collated.packages[pkgName].updateType);
+          return true;
+        }
+      }
+    }
+    return false;
+  });
+
+  indirectBumps.push(...indirectLockBumps);
+
+  // find version from updateType for both direct and indirect bumps
+  for (const [name, pkg] of Object.entries(collated.packages)) {
+    findVersion(name, (pkg as any).updateType, collated);
+  }
+
+  const directBumps = collated.realPackages.filter(
+    (name) => collated.packages[name] && collated.packages[name].newVersion
+  );
+
+  collated.directBumps = directBumps;
+  collated.indirectBumps = indirectBumps;
+  return Promise.resolve(collated);
+};

--- a/packages/fynpo/src/utils/get-updated-packages.ts
+++ b/packages/fynpo/src/utils/get-updated-packages.ts
@@ -1,0 +1,158 @@
+/* eslint-disable complexity, consistent-return, max-depth */
+
+import logger from "../logger";
+import { execSync } from "../child-process";
+import minimatch from "minimatch";
+import path from "path";
+import slash from "slash";
+import _ from "lodash";
+
+const ifTagExists = (execOptions) => {
+  let result = false;
+
+  try {
+    result = !!execSync("git", ["tag", "--list", "fynpo-rel-*"], execOptions);
+  } catch (err) {
+    logger.warn("Can't find latest release tag from this branch!");
+  }
+
+  return result;
+};
+
+const getLatestTag = (execOptions) => {
+  const args = ["describe", "--long", "--first-parent", "--match", "fynpo-rel-*"];
+  const stdout = execSync("git", args, execOptions);
+  const [, tagName, commitCount, sha] = /^(.*)-(\d+)-g([0-9a-f]+)$/.exec(stdout) || [];
+  return { tagName, commitCount, sha };
+};
+
+const addDependents = (name, changed, packages) => {
+  const dependents = _.get(packages, [name, "dependents"], {});
+  dependents.forEach((dep) => {
+    if (!changed.pkgs.includes(dep)) {
+      changed.pkgs.push(dep);
+    }
+    changed.depMap[dep] ??= [];
+    changed.depMap[dep].push(name);
+  });
+};
+
+const addVersionLocks = (name, changed, opts) => {
+  const verLocks = opts.versionLockMap[name];
+  changed.verLocks[name] = [];
+
+  if (verLocks) {
+    logger.info("version locks:", name, verLocks);
+    for (const lockPkgName of _.without(verLocks, name)) {
+      if (!changed.pkgs.includes(lockPkgName)) {
+        changed.pkgs.push(lockPkgName);
+      }
+      changed.verLocks[name].push(lockPkgName);
+    }
+  }
+};
+
+const getUpdatedPackages = (data, opts) => {
+  let latestTag;
+  const changed = {
+    pkgs: [],
+    depMap: {},
+    verLocks: {},
+    forceUpdated: [],
+    latestTag: undefined,
+  };
+  const packages = data.packages || {};
+  const forced = opts.forcePublish || [];
+  const execOpts = {
+    cwd: opts.cwd,
+  };
+
+  if (ifTagExists(execOpts)) {
+    const { tagName, commitCount } = getLatestTag(execOpts);
+    changed.latestTag = tagName;
+
+    if (commitCount === "0" && forced.length === 0) {
+      logger.info("No commits since previous release. Skipping change detection");
+      return changed;
+    }
+
+    latestTag = tagName;
+  }
+
+  if (!latestTag || forced.includes("*") || opts.lockAll) {
+    if (forced.includes("*")) {
+      logger.info("Force updating all the packages.");
+    }
+    if (opts.lockAll) {
+      logger.info("All packages are version locked.");
+    }
+    logger.info("Assuming all packages changed.");
+    Object.keys(packages).forEach((name) => {
+      changed.pkgs.push(name);
+    });
+  } else {
+    logger.info(`Detecting changed packages since the release tag: ${latestTag}`);
+
+    const ignoreChanges = opts.ignoreChanges || [];
+    if (ignoreChanges.length) {
+      logger.info("Ignoring changes in files matching patterns:", ignoreChanges);
+    }
+    const filterFunctions = ignoreChanges.map((p) =>
+      minimatch.filter(`!${p}`, {
+        matchBase: true,
+        dot: true,
+      })
+    );
+
+    const isForced = (name) => {
+      if (forced.includes("*") || forced.includes(name)) {
+        logger.info(`force updating package: ${name}`);
+        changed.forceUpdated.push(name);
+        return true;
+      }
+      return false;
+    };
+
+    const isChanged = (name) => {
+      const pkg = packages[name];
+
+      const args = ["diff", "--name-only", `${latestTag}...HEAD`];
+      const pathArg = slash(path.relative(execOpts.cwd || process.cwd(), pkg.path));
+      if (pathArg) {
+        args.push("--", pathArg);
+      }
+
+      const diff = execSync("git", args, execOpts);
+      if (diff === "") {
+        return false;
+      }
+
+      let changedFiles = diff.split("\n");
+      if (filterFunctions.length) {
+        for (const filerFn of filterFunctions) {
+          changedFiles = changedFiles.filter(filerFn);
+        }
+      }
+
+      return changedFiles.length > 0;
+    };
+
+    Object.keys(packages).forEach((name) => {
+      if (isForced(name) || isChanged(name)) {
+        changed.pkgs.push(name);
+      }
+    });
+
+    changed.pkgs.forEach((name) => {
+      addVersionLocks(name, changed, opts);
+    });
+
+    changed.pkgs.forEach((name) => {
+      addDependents(name, changed, packages);
+    });
+  }
+
+  return changed;
+};
+
+export = getUpdatedPackages;

--- a/packages/fynpo/src/utils/git-list-commits.ts
+++ b/packages/fynpo/src/utils/git-list-commits.ts
@@ -1,0 +1,133 @@
+import Promise from "bluebird";
+import Path from "path";
+import Fs from "fs";
+import minimatch from "minimatch";
+import logger from "../logger";
+import { execSync } from "../child-process";
+
+export const isAnythingCommitted = (opts) => {
+  const anyCommits = execSync("git", ["rev-list", "--count", "--all", "--max-count=1"], opts);
+
+  logger.info("isAnythingCommitted", anyCommits);
+
+  return Boolean(parseInt(anyCommits, 10));
+};
+
+export const getNewCommits = (opts, changed) => {
+  const execOpts = {
+    cwd: opts.cwd,
+  };
+
+  const tag = changed.latestTag;
+
+  let args;
+  if (tag) {
+    args = ["log", `${tag}...HEAD`, "--pretty=format:'%H %s'"];
+  } else {
+    args = ["log", "--pretty=format:'%H %s'"];
+  }
+
+  const stdout = execSync("git", args, execOpts);
+  const commits = stdout
+    .split("\n")
+    .map((x) => x.replace(/['"]+/g, ""))
+    .filter(
+      (x) => x.length > 0 && !x.startsWith("Merge pull request #") && !x.includes("[no-changelog]")
+    );
+  const commitIds = commits.reduce(
+    (a, x) => {
+      const idx = x.indexOf(" ");
+      const id = x.substr(0, idx);
+      a.ids.push(id);
+      a[id] = x.substr(idx + 1);
+      return a;
+    },
+    { ids: [] }
+  );
+
+  return Promise.resolve(commitIds).then((commitObj) => {
+    if (opts.changeLog.indexOf(commitObj.ids[0]) >= 0) {
+      logger.error("change log already contain a commit from new commits");
+      process.exit(1);
+    }
+    return { commits: commitObj, changed, opts };
+  });
+};
+
+export const collateCommitsPackages = ({ commits, changed, opts }) => {
+  const commitIds = commits.ids;
+  const execOpts = {
+    cwd: opts.cwd,
+  };
+
+  const collated = {
+    realPackages: [],
+    packages: {},
+    samples: {},
+    others: {},
+    files: {},
+    changed,
+    opts,
+  };
+
+  const ignoreChanges = opts.ignoreChanges || [];
+  if (ignoreChanges.length) {
+    logger.info("Ignoring commits in files matching patterns:", ignoreChanges);
+  }
+  const filterFunctions = ignoreChanges.map((p) =>
+    minimatch.filter(`!${p}`, {
+      matchBase: true,
+      dot: true,
+    })
+  );
+
+  return Promise.map(
+    commitIds,
+    (id) => {
+      const args = ["diff-tree", "--no-commit-id", "--name-only", "--root", "-r", `${id}`];
+      const stdout = execSync("git", args, execOpts);
+      let files = stdout.split("\n").filter((x) => x.trim().length > 0);
+
+      if (filterFunctions.length) {
+        for (const filerFn of filterFunctions) {
+          files = files.filter(filerFn);
+        }
+      }
+
+      const handled = { packages: {}, others: {}, files: {} };
+
+      files.reduce((a, x) => {
+        const parts = x.split("/");
+        const add = (group, key) => {
+          if (handled[group][key]) return;
+          a[group][key] ??= {};
+          if (!a[group][key].msgs) {
+            a[group][key].msgs = [];
+          }
+          a[group][key].msgs.push({ m: commits[id], id });
+          handled[group][key] = true;
+        };
+
+        if (parts[0] === "packages" || parts[0] === "samples") {
+          if (Fs.existsSync(Path.resolve("packages", parts[1]))) {
+            /* eslint-disable @typescript-eslint/no-var-requires */
+            const Pkg = require(Path.resolve("packages", parts[1], "package.json"));
+            if (parts[0] === "packages" && collated.realPackages.indexOf(Pkg.name) < 0) {
+              collated.realPackages.push(Pkg.name);
+              a.packages[Pkg.name] = { dirName: parts[1] };
+            }
+            add(parts[0], Pkg.name);
+          }
+        } else if (parts.length > 1) {
+          add("others", parts[0]);
+        } else {
+          add("files", parts[0]);
+        }
+
+        return a;
+      }, collated);
+      return "";
+    },
+    { concurrency: 1 }
+  ).then(() => collated);
+};

--- a/packages/fynpo/src/utils/update-changelog-file.ts
+++ b/packages/fynpo/src/utils/update-changelog-file.ts
@@ -1,0 +1,138 @@
+/* eslint-disable complexity, consistent-return, max-depth */
+
+import Path from "path";
+import Fs from "fs";
+import semver from "semver";
+import _ from "lodash";
+
+const getTaggedVersion = (pkg, fynpoRc) => {
+  const newVer = pkg.newVersion;
+  const semv = pkg.semver;
+
+  const fynpoTags = _.get(fynpoRc, "command.publish.tags");
+  const graduatePkgs = _.get(fynpoRc, "graduate", []);
+  const graduateAll = graduatePkgs[0] && graduatePkgs[0] === "*";
+
+  if (fynpoTags) {
+    for (const tag in fynpoTags) {
+      if (!tag.match(/^[0-9A-Za-z-]+$/)) {
+        throw new Error(`tag ${tag} invalid. Only [0-9A-Za-z-] characters allowed.`);
+      }
+      const tagInfo = fynpoTags[tag];
+      if (tagInfo.enabled === false) continue;
+      const enabled = _.get(tagInfo, ["packages", pkg.originalPkg.name]);
+      if (enabled) {
+        if (tag !== "latest" && tagInfo.addToVersion) {
+          if (semv.prerelease[0] && semv.prerelease[0] === tag) {
+            return semv.inc("prerelease").format();
+          }
+          return `${pkg.newVersion}-${tag}.0`;
+        }
+      }
+    }
+  }
+
+  if (semv.prerelease && semv.prerelease.length > 0) {
+    if (graduateAll || graduatePkgs.indexOf(pkg.originalPkg.name) >= 0) {
+      return semver.parse(pkg.versionOnly);
+    }
+    return semv.inc("prerelease").format();
+  }
+
+  return newVer;
+};
+
+export const updateChangelog = (collated) => {
+  const d = new Date();
+  const output = [];
+  const opts = collated.opts || {};
+  const cwd = opts.cwd || process.cwd();
+  const versions = {};
+  const tags = [];
+
+  const forceUpdated = collated.indirectBumps.length > 0;
+
+  let rootPkg;
+  try {
+    rootPkg = require(Path.join(cwd, "package.json"));
+  } catch (err) {
+    rootPkg = {};
+  }
+
+  output.push(`# ${d.getMonth() + 1}/${d.getDate()}/${d.getFullYear()}\n\n## Packages\n\n`);
+  if (forceUpdated) {
+    output.push(`### Directly Updated\n\n`);
+  }
+
+  const emitPackageMsg = (p, packages) => {
+    const pkg = packages[p];
+    const newVer = getTaggedVersion(pkg, opts.fynpoRc);
+    if (pkg.originalPkg.private) return;
+    /* eslint-disable no-useless-concat */
+    output.push(`-   \`${p}@${newVer}\` ` + "`" + `(${pkg.version} => ${newVer})` + "`\n");
+    versions[p] = newVer;
+    tags.push(`${p}@${newVer}`);
+  };
+  collated.directBumps.sort().forEach((p) => emitPackageMsg(p, collated.packages));
+
+  if (forceUpdated) {
+    output.push(`\n### Fynpo Updated\n\n`);
+    collated.indirectBumps.sort().forEach((p) => emitPackageMsg(p, collated.packages));
+  }
+  output.push(`\n## Commits\n\n`);
+
+  let repoUrl = _.get(rootPkg, "repository.url", "REPO_URL").trim();
+  if (repoUrl.endsWith(".git")) {
+    repoUrl = repoUrl.slice(0, -4);
+  }
+  const commitUrl = `${repoUrl}/commit`;
+  const prUrl = `${repoUrl}/pull`;
+
+  const linkifyPR = (x) => x.replace(/\(#([0-9]+)\)$/, `([#$1](${prUrl}/$1))`);
+
+  const emitCommitMsg = (msg) => {
+    emitCommitMsg[msg.id] = true;
+    output.push(`    -   ${linkifyPR(msg.m)} [commit](${commitUrl}/${msg.id})\n`);
+  };
+
+  const outputCommitMsgs = (items, prefix) => {
+    const keys = Object.keys(items);
+    if (keys.length === 0) return;
+    keys.sort().forEach((p) => {
+      const pkg = items[p];
+      const dirName = pkg.dirName || p;
+      if (!pkg.msgs || pkg.msgs.length === 0) return;
+      output.push("-   `" + prefix + dirName + "`\n\n");
+      pkg.msgs.slice().forEach(emitCommitMsg);
+      output.push("\n");
+    });
+  };
+
+  const outputPkgCommitMsgs = (group, prefix) => {
+    const items = collated[group];
+    outputCommitMsgs(items, prefix ? group + "/" : "");
+  };
+
+  outputPkgCommitMsgs("packages", true);
+  outputPkgCommitMsgs("samples", true);
+  outputPkgCommitMsgs("others", false);
+  const filesItems = Object.keys(collated.files).reduce(
+    (a, x) => {
+      a.MISC.msgs = a.MISC.msgs.concat(
+        collated.files[x].msgs.filter((msg) => {
+          if (!emitCommitMsg[msg.id]) {
+            return (emitCommitMsg[msg.id] = true);
+          }
+          return false;
+        })
+      );
+      return a;
+    },
+    { MISC: { msgs: [] } }
+  );
+  outputCommitMsgs(filesItems, "");
+
+  const updateText = output.join("");
+  Fs.writeFileSync(opts.changeLogFile, `${updateText}${opts.changeLog}`);
+  return Promise.resolve({ versions, tags, collated });
+};

--- a/packages/fynpo/src/utils/update-package-versions.ts
+++ b/packages/fynpo/src/utils/update-package-versions.ts
@@ -1,0 +1,128 @@
+import _ from "lodash";
+import Path from "path";
+import Fs from "fs";
+import Chalk from "chalk";
+import assert from "assert";
+import semver from "semver";
+import logger from "../logger";
+
+const checkNupdateTag = (pkg, newV, opts) => {
+  const { pkgJson } = pkg;
+  const fynpoTags = _.get(opts.fynpoRc, "command.publish.tags");
+  const versionTagging = _.get(opts.fynpoRc, "command.publish.versionTagging", {});
+  const existPubConfig = _.get(pkgJson, "publishConfig");
+
+  let updated;
+
+  if (fynpoTags) {
+    Object.keys(fynpoTags).find((tag) => {
+      const tagInfo = fynpoTags[tag];
+      if (tagInfo.enabled === false) {
+        return undefined;
+      }
+
+      let enabled = _.get(tagInfo, ["packages", pkgJson.name]);
+
+      if (enabled === undefined && tagInfo.regex) {
+        enabled = Boolean(tagInfo.regex.find((r) => new RegExp(r).exec(pkgJson.name)));
+      }
+
+      const tagPkgs = _.get(tagInfo, "packages");
+      if (tagInfo.enabled === false || !tagPkgs.hasOwnProperty(pkgJson.name)) {
+        return undefined;
+      }
+
+      if (!enabled) {
+        // npm tag not enabled for package
+        if (pkgJson.publishConfig) {
+          // remove tag from package.json if it exist
+          delete pkgJson.publishConfig.tag;
+        }
+        // default to latest tag
+        return (updated = "latest");
+      }
+
+      // enabled, update tag in package.json
+      pkgJson.publishConfig = Object.assign({}, pkgJson.publishConfig, { tag });
+      return (updated = tag);
+    });
+  }
+
+  if (versionTagging.hasOwnProperty(pkgJson.name)) {
+    assert(!updated, `package ${pkgJson.name} has both tag and versionTagging`);
+    const semv = semver.parse(newV);
+    const tag = `ver${semv.major}`;
+    pkgJson.publishConfig = Object.assign({}, pkgJson.publishConfig, { tag });
+    updated = tag;
+  }
+
+  // reset exist tag to latest in case lerna config
+  if (existPubConfig && !updated && existPubConfig.tag && existPubConfig.tag !== "latest") {
+    logger.warn(
+      Chalk.red(
+        `Pkg ${pkgJson.name} has exist publishConfig.tag ${existPubConfig.tag} \
+that's not latest but none set in fynpo config`
+      )
+    );
+    // existPubConfig.tag = "latest";
+  }
+
+  pkgJson.version = newV;
+};
+
+const updateDep = (pkg, name, ver) => {
+  ["dependencies", "optionalDependencies", "peerDependencies", "devDependencies"].forEach((sec) => {
+    const deps = pkg[sec];
+    if (_.isEmpty(deps) || !deps.hasOwnProperty(name)) {
+      return;
+    }
+
+    let semType = "";
+    const sem = deps[name][0];
+
+    if (sem.match(/[\^~]/)) {
+      semType = sem;
+    } else if (!sem.match(/[0-9]/)) {
+      return;
+    }
+
+    deps[name] = `${semType}${ver}`;
+  });
+};
+
+export const updatePackageVersions = ({ versions, tags, collated }) => {
+  if (_.isEmpty(versions)) {
+    logger.error("No versions found in CHANGELOG.md");
+    return undefined;
+  }
+
+  const data = _.get(collated, "opts.data", { packages: {} });
+
+  const packages = [];
+
+  _.each(data.packages, (pkg, name) => {
+    if (!versions.hasOwnProperty(name)) return;
+
+    const newV = versions[name];
+    if (newV === pkg.version) return;
+
+    if (pkg.private === true) {
+      logger.info("skipping private package", pkg.name);
+      return;
+    }
+
+    checkNupdateTag(pkg, newV, collated.opts);
+
+    _.each(versions, (ver, name2) => {
+      updateDep(pkg.pkgJson, name2, ver);
+    });
+
+    packages.push(Path.join("packages", pkg.pkgDir, "package.json"));
+  });
+  // all updated, write to disk
+  _.each(data.packages, (pkg) => {
+    Fs.writeFileSync(pkg.pkgFile, `${JSON.stringify(pkg.pkgJson, null, 2)}\n`);
+  });
+
+  return Promise.resolve({ packages, tags });
+};


### PR DESCRIPTION
- Added `fynpo version` command (changelog+prepare)
- `fynpo changelog --publish` (same as above, changelog+preprae)
- Use same logic to detect changed packages in `updated`, `changelog` and `version` commands
- Support `versionLock`, `forcePublish` and `ignoreChanges` in detecting changed packages
- Fix issue with the order of commit messages in changelog
- Code refactoring to improve reusabilty